### PR TITLE
[Feature] Pagination 적용

### DIFF
--- a/src/main/java/team/moca/camo/api/KakaoAuthApiService.java
+++ b/src/main/java/team/moca/camo/api/KakaoAuthApiService.java
@@ -1,5 +1,6 @@
 package team.moca.camo.api;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Getter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -66,5 +67,6 @@ public class KakaoAuthApiService {
 @Getter
 class KakaoTokenResponse {
 
+    @JsonAlias(value = "id")
     private String kakaoId;
 }

--- a/src/main/java/team/moca/camo/common/GuestUser.java
+++ b/src/main/java/team/moca/camo/common/GuestUser.java
@@ -2,7 +2,6 @@ package team.moca.camo.common;
 
 import lombok.Getter;
 import team.moca.camo.domain.User;
-import team.moca.camo.domain.value.UserType;
 
 @Getter
 public class GuestUser {
@@ -13,7 +12,6 @@ public class GuestUser {
             .phone("01012345678")
             .nickname("Guest")
             .kakaoId("12345678")
-            .userType(UserType.GUEST)
             .build();
 
     private GuestUser() {

--- a/src/main/java/team/moca/camo/controller/CafeController.java
+++ b/src/main/java/team/moca/camo/controller/CafeController.java
@@ -26,8 +26,8 @@ public class CafeController {
 
     @GetMapping("/nearby")
     public PageResponseDto<List<CafeListResponse>> userNearbyCafeList(
-            @Authenticate(required = false) String authenticatedAccountId, @RequestBody Coordinates coordinates,
-            @RequestParam(name = "page", defaultValue = "0") int page
+            @Authenticate(required = false) String authenticatedAccountId,
+            @RequestBody Coordinates coordinates, @RequestParam(name = "page", defaultValue = "0") int page
     ) {
         PageDto pageDto = PageDto.of(page);
         List<CafeListResponse> nearbyCafeList = cafeService.getNearbyCafeList(coordinates, authenticatedAccountId, pageDto);

--- a/src/main/java/team/moca/camo/controller/CafeController.java
+++ b/src/main/java/team/moca/camo/controller/CafeController.java
@@ -3,10 +3,12 @@ package team.moca.camo.controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team.moca.camo.common.annotation.Authenticate;
-import team.moca.camo.controller.dto.CafeListResponse;
-import team.moca.camo.controller.dto.ResponseDto;
+import team.moca.camo.controller.dto.PageDto;
+import team.moca.camo.controller.dto.PageResponseDto;
+import team.moca.camo.controller.dto.response.CafeListResponse;
 import team.moca.camo.domain.value.Coordinates;
 import team.moca.camo.service.CafeService;
 
@@ -23,10 +25,12 @@ public class CafeController {
     }
 
     @GetMapping("/nearby")
-    public ResponseDto<List<CafeListResponse>> userNearbyCafeList(
-            @Authenticate(required = false) String authenticatedAccountId, @RequestBody Coordinates coordinates
+    public PageResponseDto<List<CafeListResponse>> userNearbyCafeList(
+            @Authenticate(required = false) String authenticatedAccountId, @RequestBody Coordinates coordinates,
+            @RequestParam(name = "page", defaultValue = "0") int page
     ) {
-        List<CafeListResponse> nearbyCafeList = cafeService.getNearbyCafeList(coordinates, authenticatedAccountId);
-        return ResponseDto.of(nearbyCafeList, "User's nearby cafe list.");
+        PageDto pageDto = PageDto.of(page);
+        List<CafeListResponse> nearbyCafeList = cafeService.getNearbyCafeList(coordinates, authenticatedAccountId, pageDto);
+        return PageResponseDto.of(nearbyCafeList, "User's nearby cafe list.", pageDto);
     }
 }

--- a/src/main/java/team/moca/camo/controller/dto/DefaultResponseData.java
+++ b/src/main/java/team/moca/camo/controller/dto/DefaultResponseData.java
@@ -1,0 +1,13 @@
+package team.moca.camo.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DefaultResponseData<T> implements ResponseData<T> {
+
+    private final T body;
+
+    protected DefaultResponseData(T body) {
+        this.body = body;
+    }
+}

--- a/src/main/java/team/moca/camo/controller/dto/PageDto.java
+++ b/src/main/java/team/moca/camo/controller/dto/PageDto.java
@@ -1,22 +1,27 @@
 package team.moca.camo.controller.dto;
 
 import lombok.Getter;
+import team.moca.camo.exception.BusinessException;
+import team.moca.camo.exception.error.FieldError;
 
 @Getter
 public class PageDto {
 
     private final int nowPage;
-    private int maxPage;
+    private int totalPages;
 
     protected PageDto(int nowPage) {
         this.nowPage = nowPage;
     }
 
     public static PageDto of(int nowPage) {
+        if (nowPage < 0) {
+            throw new BusinessException(FieldError.INVALID_PAGE);
+        }
         return new PageDto(nowPage);
     }
 
-    public void updateMaxPage(int maxPage) {
-        this.maxPage = maxPage;
+    public void updateTotalPages(int totalPages) {
+        this.totalPages = totalPages;
     }
 }

--- a/src/main/java/team/moca/camo/controller/dto/PageDto.java
+++ b/src/main/java/team/moca/camo/controller/dto/PageDto.java
@@ -1,0 +1,22 @@
+package team.moca.camo.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PageDto {
+
+    private final int nowPage;
+    private int maxPage;
+
+    protected PageDto(int nowPage) {
+        this.nowPage = nowPage;
+    }
+
+    public static PageDto of(int nowPage) {
+        return new PageDto(nowPage);
+    }
+
+    public void updateMaxPage(int maxPage) {
+        this.maxPage = maxPage;
+    }
+}

--- a/src/main/java/team/moca/camo/controller/dto/PageResponseData.java
+++ b/src/main/java/team/moca/camo/controller/dto/PageResponseData.java
@@ -1,0 +1,15 @@
+package team.moca.camo.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PageResponseData<T> implements ResponseData<T> {
+
+    private final T body;
+    private final PageDto page;
+
+    public PageResponseData(T body, PageDto page) {
+        this.body = body;
+        this.page = page;
+    }
+}

--- a/src/main/java/team/moca/camo/controller/dto/PageResponseDto.java
+++ b/src/main/java/team/moca/camo/controller/dto/PageResponseDto.java
@@ -1,0 +1,25 @@
+package team.moca.camo.controller.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PageResponseDto<T> extends ResponseDto<T> {
+
+    protected PageResponseDto(LocalDateTime timeStamp, String message, T data, PageDto pageDto) {
+        super(timeStamp, message, new PageResponseData<>(data, pageDto));
+    }
+
+    public static <T> PageResponseDto<T> of(String message, PageDto pageDto) {
+        return new PageResponseDto<>(LocalDateTime.now(), message, null, pageDto);
+    }
+
+    public static <T> PageResponseDto<T> of(T body, PageDto pageDto) {
+        return new PageResponseDto<>(LocalDateTime.now(), null, body, pageDto);
+    }
+
+    public static <T> PageResponseDto<T> of(T body, String message, PageDto pageDto) {
+        return new PageResponseDto<>(LocalDateTime.now(), message, body, pageDto);
+    }
+}

--- a/src/main/java/team/moca/camo/controller/dto/ResponseData.java
+++ b/src/main/java/team/moca/camo/controller/dto/ResponseData.java
@@ -1,0 +1,6 @@
+package team.moca.camo.controller.dto;
+
+public interface ResponseData<T> {
+
+    T getBody();
+}

--- a/src/main/java/team/moca/camo/controller/dto/ResponseDto.java
+++ b/src/main/java/team/moca/camo/controller/dto/ResponseDto.java
@@ -9,12 +9,12 @@ public class ResponseDto<T> {
 
     private final LocalDateTime timeStamp;
     private final String message;
-    private final T body;
+    private final ResponseData<T> data;
 
-    protected ResponseDto(LocalDateTime timeStamp, String message, T body) {
+    protected ResponseDto(LocalDateTime timeStamp, String message, ResponseData<T> data) {
         this.timeStamp = timeStamp;
         this.message = message;
-        this.body = body;
+        this.data = data;
     }
 
     public static <T> ResponseDto<T> of(String message) {
@@ -22,10 +22,10 @@ public class ResponseDto<T> {
     }
 
     public static <T> ResponseDto<T> of(T body) {
-        return new ResponseDto<>(LocalDateTime.now(), null, body);
+        return new ResponseDto<>(LocalDateTime.now(), null, new DefaultResponseData<>(body));
     }
 
     public static <T> ResponseDto<T> of(T body, String message) {
-        return new ResponseDto<>(LocalDateTime.now(), message, body);
+        return new ResponseDto<>(LocalDateTime.now(), message, new DefaultResponseData<>(body));
     }
 }

--- a/src/main/java/team/moca/camo/controller/dto/response/CafeListResponse.java
+++ b/src/main/java/team/moca/camo/controller/dto/response/CafeListResponse.java
@@ -1,4 +1,4 @@
-package team.moca.camo.controller.dto;
+package team.moca.camo.controller.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -7,15 +7,12 @@ import team.moca.camo.domain.Cafe;
 @Getter
 public class CafeListResponse {
 
-    private String cafeId;
-    private String cafeName;
-    private String location;
-    private double ratingAverage;
-    private int favoritesCount;
-    private boolean isFavorite;
-
-    protected CafeListResponse() {
-    }
+    private final String cafeId;
+    private final String cafeName;
+    private final String location;
+    private final double ratingAverage;
+    private final int favoritesCount;
+    private final boolean isFavorite;
 
     @Builder
     protected CafeListResponse(String cafeId, String cafeName, String location, double ratingAverage,

--- a/src/main/java/team/moca/camo/domain/Cafe.java
+++ b/src/main/java/team/moca/camo/domain/Cafe.java
@@ -70,7 +70,7 @@ public class Cafe extends BaseEntity {
             joinColumns = @JoinColumn(name = "cafe_id"),
             inverseJoinColumns = @JoinColumn(name = "tag_id"))
     @ManyToMany
-    private List<Cafe> cafes = new ArrayList<>();
+    private List<Tag> tags = new ArrayList<>();
 
     @OneToMany(mappedBy = "cafe")
     private List<Image> images = new ArrayList<>();

--- a/src/main/java/team/moca/camo/domain/User.java
+++ b/src/main/java/team/moca/camo/domain/User.java
@@ -94,14 +94,13 @@ public class User extends BaseEntity implements UserDetails {
     }
 
     @Builder
-    protected User(String email, String password, String phone, String nickname, String kakaoId, UserType userType) {
+    protected User(String email, String password, String phone, String nickname, String kakaoId) {
         this();
         this.email = email;
         this.password = password;
         this.phone = phone;
         this.nickname = nickname;
         this.kakaoId = kakaoId;
-        this.userType = userType;
     }
 
     public static User signUp(SignUpRequest signUpRequest, String encodedPassword) {

--- a/src/main/java/team/moca/camo/domain/User.java
+++ b/src/main/java/team/moca/camo/domain/User.java
@@ -60,7 +60,7 @@ public class User extends BaseEntity implements UserDetails {
     @Column(name = "nickname", length = 10)
     private String nickname;
 
-    @Column(name = "kakao_id", length = 50)
+    @Column(name = "kakao_id", unique = true, length = 50)
     private String kakaoId;
 
     @Column(name = "withdrawn")

--- a/src/main/java/team/moca/camo/exception/error/AuthenticationError.java
+++ b/src/main/java/team/moca/camo/exception/error/AuthenticationError.java
@@ -11,7 +11,8 @@ public enum AuthenticationError implements CamoError {
     EMAIL_DUPLICATION("C0003", "중복된 이메일입니다."),
     PHONE_DUPLICATION("C0004", "중복된 전화번호입니다."),
     NICKNAME_DUPLICATION("C0005", "중복된 닉네임입니다."),
-    PASSWORD_CHECK_MISMATCH("C0006", "비밀번호 확인이 일치하지 않습니다.");
+    PASSWORD_CHECK_MISMATCH("C0006", "비밀번호 확인이 일치하지 않습니다."),
+    KAKAO_ACCOUNT_ALREADY_INTEGRATED("C007", "해당 카카오 계정은 이미 연동되어 있습니다.");
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/team/moca/camo/exception/error/FieldError.java
+++ b/src/main/java/team/moca/camo/exception/error/FieldError.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum FieldError implements CamoError {
 
-    INVALID_FIELD("C1001", "필드 유효성 검증에 실패하였습니다.");
+    INVALID_FIELD("C1001", "필드 유효성 검증에 실패하였습니다."),
+    INVALID_PAGE("C1002", "유효하지 않은 페이지입니다.");
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/team/moca/camo/repository/CafeRepository.java
+++ b/src/main/java/team/moca/camo/repository/CafeRepository.java
@@ -1,14 +1,14 @@
 package team.moca.camo.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import team.moca.camo.domain.Cafe;
 
-import java.util.List;
-
 public interface CafeRepository extends JpaRepository<Cafe, String> {
 
     @Query(value = "SELECT c FROM Cafe c WHERE c.address.city = :city")
-    List<Cafe> findByCity(@Param(value = "city") String city);
+    Page<Cafe> findByCity(@Param(value = "city") String city, Pageable pageable);
 }

--- a/src/main/java/team/moca/camo/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/team/moca/camo/security/jwt/JwtAuthenticationFilter.java
@@ -36,10 +36,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         validateRequestTokenHeader(requestTokenHeader);
 
         String requestToken = requestTokenHeader.substring(TOKEN_PREFIX.length());
-        validateRequestToken(requestToken);
 
-        Authentication authentication = jwtUtils.getAuthentication(requestToken);
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+        if (jwtUtils.isValidToken(requestToken)) {
+            Authentication authentication = jwtUtils.getAuthentication(requestToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
 
         filterChain.doFilter(request, response);
     }
@@ -48,12 +49,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (!StringUtils.startsWith(requestTokenHeader, TOKEN_PREFIX)) {
             logger.error("Authorization request header does not begin with 'Bearer ' String!");
             throw new RuntimeException("Authorization request header does not begin with 'Bearer ' String!");
-        }
-    }
-
-    private void validateRequestToken(String requestToken) {
-        if (!jwtUtils.isValidToken(requestToken)) {
-            throw new RuntimeException("JWT is invalid!");
         }
     }
 }

--- a/src/main/java/team/moca/camo/service/AuthenticationService.java
+++ b/src/main/java/team/moca/camo/service/AuthenticationService.java
@@ -85,6 +85,7 @@ public class AuthenticationService {
 
         User signUpUser = User.signUp(signUpRequest, encodedPassword);
         User savedUser = userRepository.save(signUpUser);
+
         return savedUser.getId();
     }
 
@@ -123,6 +124,11 @@ public class AuthenticationService {
                 .orElseThrow(() -> new BusinessException(AuthenticationError.USER_AUTHENTICATION_FAIL));
 
         String kakaoAccountId = kakaoAuthApiService.getKakaoAccountId(kakaoToken);
+        Optional<User> optionalUser = userRepository.findByKakaoId(kakaoAccountId);
+        if (optionalUser.isPresent()) {
+            throw new BusinessException(AuthenticationError.KAKAO_ACCOUNT_ALREADY_INTEGRATED);
+        }
+
         authenticatedUser.integrateKakaoAccount(kakaoAccountId);
     }
 
@@ -151,8 +157,7 @@ public class AuthenticationService {
 
         String accessToken = jwtUtils.generateToken(user, ACCESS_TOKEN_VALIDITY_PERIOD);
         String refreshToken = jwtUtils.generateToken(user, REFRESH_TOKEN_VALIDITY_PERIOD);
-
-        log.info("User login [{}]", user.getEmail());
+        log.info("User login with Kakao [{}]", user.getEmail());
         return new LoginResponse(accessToken, refreshToken);
     }
 }

--- a/src/main/java/team/moca/camo/service/CafeService.java
+++ b/src/main/java/team/moca/camo/service/CafeService.java
@@ -1,12 +1,15 @@
 package team.moca.camo.service;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.moca.camo.api.KakaoLocalApiService;
 import team.moca.camo.api.dto.KakaoAddressResponse;
 import team.moca.camo.common.GuestUser;
-import team.moca.camo.controller.dto.CafeListResponse;
+import team.moca.camo.controller.dto.PageDto;
+import team.moca.camo.controller.dto.response.CafeListResponse;
 import team.moca.camo.domain.Cafe;
 import team.moca.camo.domain.Favorite;
 import team.moca.camo.domain.User;
@@ -25,6 +28,8 @@ import java.util.stream.Collectors;
 @Service
 public class CafeService {
 
+    private static final int DEFAULT_PAGE_LIST_SIZE = 10;
+
     private final CafeRepository cafeRepository;
     private final CafeLocationRepository cafeLocationRepository;
     private final KakaoLocalApiService kakaoLocalApiService;
@@ -37,18 +42,18 @@ public class CafeService {
         this.userRepository = userRepository;
     }
 
-    public List<CafeListResponse> getNearbyCafeList(final Coordinates userCoordinates, final String authenticatedAccountId) {
+    public List<CafeListResponse> getNearbyCafeList(final Coordinates userCoordinates, final String authenticatedAccountId, final PageDto page) {
         User requestUser = getAuthenticatedUserOrGuestUser(authenticatedAccountId);
 
         KakaoAddressResponse userAddress = kakaoLocalApiService.coordinatesToAddress(userCoordinates);
         String region2depthName = userAddress.getRegion2depthName();
 
-        List<Cafe> nearbyCafes = cafeRepository.findByCity(region2depthName);
+        Page<Cafe> nearbyCafes =
+                cafeRepository.findByCity(region2depthName, PageRequest.of(page.getNowPage(), DEFAULT_PAGE_LIST_SIZE));
+        page.updateMaxPage(nearbyCafes.getTotalPages() - 1);
+
         return nearbyCafes.stream()
-                .map(cafe -> {
-                    boolean isFavorite = isFavoriteByUser(requestUser, cafe);
-                    return CafeListResponse.of(cafe, isFavorite);
-                })
+                .map(cafe -> CafeListResponse.of(cafe, isFavoriteByUser(requestUser, cafe)))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/team/moca/camo/service/CafeService.java
+++ b/src/main/java/team/moca/camo/service/CafeService.java
@@ -50,7 +50,7 @@ public class CafeService {
 
         Page<Cafe> nearbyCafes =
                 cafeRepository.findByCity(region2depthName, PageRequest.of(page.getNowPage(), DEFAULT_PAGE_LIST_SIZE));
-        page.updateMaxPage(nearbyCafes.getTotalPages() - 1);
+        page.updateTotalPages(nearbyCafes.getTotalPages());
 
         return nearbyCafes.stream()
                 .map(cafe -> CafeListResponse.of(cafe, isFavoriteByUser(requestUser, cafe)))

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS User
     password   VARCHAR(255) NOT NULL,
     phone      VARCHAR(15)  NOT NULL UNIQUE,
     nickname   VARCHAR(10),
-    kakao_id   VARCHAR(50),
+    kakao_id   VARCHAR(50) UNIQUE,
     withdrawn  BOOLEAN DEFAULT FALSE,
     user_type  VARCHAR(15)  NOT NULL,
     created_at DATETIME(6)  NOT NULL,

--- a/src/test/java/team/moca/camo/service/CafeServiceTest.java
+++ b/src/test/java/team/moca/camo/service/CafeServiceTest.java
@@ -7,11 +7,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import team.moca.camo.TestUtils;
 import team.moca.camo.api.KakaoLocalApiService;
 import team.moca.camo.api.dto.KakaoAddressResponse;
 import team.moca.camo.common.GuestUser;
-import team.moca.camo.controller.dto.CafeListResponse;
+import team.moca.camo.controller.dto.PageDto;
+import team.moca.camo.controller.dto.response.CafeListResponse;
 import team.moca.camo.domain.Cafe;
 import team.moca.camo.domain.User;
 import team.moca.camo.domain.embedded.Address;
@@ -24,6 +27,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @Slf4j
@@ -56,16 +60,16 @@ class CafeServiceTest {
                 .thenReturn(addressResponse);
 
         Cafe testCafe = Cafe.builder().name("Cafe A").address(Address.builder().city("test").town("test").build()).build();
-        when(cafeRepository.findByCity(addressResponse.getRegion2depthName()))
-                .thenReturn(List.of(
+        when(cafeRepository.findByCity(eq(addressResponse.getRegion2depthName()), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(
                         testCafe,
                         Cafe.builder().name("Cafe B").address(Address.builder().city("test").town("test").build()).build(),
                         Cafe.builder().name("Cafe C").address(Address.builder().city("test").town("test").build()).build()
-                ));
+                )));
 
         // then
         List<CafeListResponse> nearbyCafeList =
-                cafeService.getNearbyCafeList(Coordinates.of(37.1234, 127.1234), testUser.getId());
+                cafeService.getNearbyCafeList(Coordinates.of(37.1234, 127.1234), testUser.getId(), PageDto.of(0));
 
         assertThat(nearbyCafeList).isNotNull();
         assertThat(nearbyCafeList.size()).isEqualTo(3);
@@ -87,16 +91,16 @@ class CafeServiceTest {
                 .thenReturn(addressResponse);
 
         Cafe testCafe = Cafe.builder().name("Cafe A").address(Address.builder().city("test").town("test").build()).build();
-        when(cafeRepository.findByCity(addressResponse.getRegion2depthName()))
-                .thenReturn(List.of(
+        when(cafeRepository.findByCity(eq(addressResponse.getRegion2depthName()), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(
                         testCafe,
                         Cafe.builder().name("Cafe B").address(Address.builder().city("test").town("test").build()).build(),
                         Cafe.builder().name("Cafe C").address(Address.builder().city("test").town("test").build()).build()
-                ));
+                )));
 
         // then
         List<CafeListResponse> nearbyCafeList =
-                cafeService.getNearbyCafeList(Coordinates.of(37.1234, 127.1234), testUser.getId());
+                cafeService.getNearbyCafeList(Coordinates.of(37.1234, 127.1234), testUser.getId(), PageDto.of(0));
 
         assertThat(nearbyCafeList).isNotNull();
         assertThat(nearbyCafeList.size()).isEqualTo(3);


### PR DESCRIPTION
## Pagination 기능 적용
현재는 한 페이지 당 10개의 요소를 응답합니다. 해당 부분은 추후에 쉽게 변경 가능합니다.

응답 내용에는 데이터 내용과 현재 페이지, 전체 페이지를 포함합니다. 페이지 요청 검증은 0 이하 음수인 경우에만 '유효하지 않는 페이지' 예외 처리를 하였습니다.
전체 페이지수를 초과하는 페이지를 요청하면 그냥 빈 list로 전달됩니다. 따라서 페이지 수가 초과되지 않도록 클라이언트에서 잘 처리해 주어야 합니다.

#8 